### PR TITLE
Fix navigation issues on trip settings and edit screens

### DIFF
--- a/lib/features/trips/presentation/pages/trip_edit_page.dart
+++ b/lib/features/trips/presentation/pages/trip_edit_page.dart
@@ -46,7 +46,7 @@ class _TripEditPageState extends State<TripEditPage> {
             name: _nameController.text.trim(),
             baseCurrency: _selectedCurrency,
           );
-      context.pop();
+      context.go('/trips/${widget.trip.id}/settings');
     }
   }
 
@@ -55,6 +55,13 @@ class _TripEditPageState extends State<TripEditPage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Edit Trip'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          tooltip: 'Back to Settings',
+          onPressed: () {
+            context.go('/trips/${widget.trip.id}/settings');
+          },
+        ),
       ),
       body: Form(
         key: _formKey,

--- a/lib/features/trips/presentation/pages/trip_settings_page.dart
+++ b/lib/features/trips/presentation/pages/trip_settings_page.dart
@@ -28,6 +28,13 @@ class TripSettingsPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Trip Settings'),
         elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          tooltip: 'Back to Expenses',
+          onPressed: () {
+            context.go('/trips/$tripId/expenses');
+          },
+        ),
         actions: [
           IconButton(
             icon: const Icon(Icons.edit),


### PR DESCRIPTION
- Add explicit back button to trip settings screen that navigates to expenses
- Add explicit back button to trip edit screen that navigates to settings
- Replace context.pop() with context.go() for consistent navigation behavior
- Fixes web back button glitches caused by mixed navigation methods

Fixes #1