### PR TITLE
Fix: Use context.pop() for back navigation from settings to expenses

### DIFF
--- a/lib/features/trips/presentation/pages/trip_settings_page.dart
+++ b/lib/features/trips/presentation/pages/trip_settings_page.dart
@@ -32,7 +32,7 @@ class TripSettingsPage extends StatelessWidget {
           icon: const Icon(Icons.arrow_back),
           tooltip: 'Back to Expenses',
           onPressed: () {
-            context.go('/trips/$tripId/expenses');
+            context.pop();
           },
         ),
         actions: [


### PR DESCRIPTION
Changed the back button in TripSettingsPage from `context.go()` to `context.pop()` to ensure proper navigation stack animation. This makes the back navigation consistent with the Edit Trip → Settings back navigation which already uses the proper stack-based approach.

Fixes #3

Generated with [Claude Code](https://claude.ai/code)