### PR TITLE
fix: rewrite Everyone's Summary to calculate from settlement transfers

### DIFF
--- a/lib/features/settlements/presentation/pages/settlement_summary_page.dart
+++ b/lib/features/settlements/presentation/pages/settlement_summary_page.dart
@@ -169,7 +169,7 @@ class _SettlementSummaryPageState extends State<SettlementSummaryPage> {
 
                       // Summary table
                       AllPeopleSummaryTable(
-                        personSummaries: state.summary.personSummaries,
+                        activeTransfers: state.activeTransfers,
                         baseCurrency: state.summary.baseCurrency,
                         participants: participants,
                       ),


### PR DESCRIPTION
Previously, the Everyone's Summary table showed raw "paid" and "owed" amounts with net balances calculated as (paid - owed). This didn't match the Settlement Transfers section which shows optimized transfers after pairwise netting.

For example, Izzy would show owing ₫127,500 in the summary but only ₫80,000 to Ethan in the transfers.

## Changes
- Updated AllPeopleSummaryTable to accept activeTransfers instead of personSummaries
- Created _PersonTransferSummary to calculate per-person totals from transfers
- Changed columns from "Paid/Owe d/Balance" to "To Receive/To Pay/Net"
- Updated legend text for clarity

Now the summary shows exactly what each person will receive/pay based on the actual settlement transfers, matching the transfers section.

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)