### PR TITLE
Fix: Use context.push() for navigation to settings page

### DIFF
--- a/lib/features/expenses/presentation/pages/expense_list_page.dart
+++ b/lib/features/expenses/presentation/pages/expense_list_page.dart
@@ -29,7 +29,7 @@ class ExpenseListPage extends StatelessWidget {
             icon: const Icon(Icons.settings),
             tooltip: 'Trip Settings',
             onPressed: () {
-              context.go('/trips/$tripId/settings');
+              context.push('/trips/$tripId/settings');
             },
           ),
           IconButton(


### PR DESCRIPTION
Changed the navigation from expenses page to settings page to use `context.push()` instead of `context.go()`. This ensures the settings page is pushed onto the navigation stack, allowing `context.pop()` to work correctly for back navigation.

This fixes the regression where the back button stopped working after the previous animation fix.

Fixes #3

Generated with [Claude Code](https://claude.ai/code)