### PR TITLE
Fix transfer breakdown to show direct pairwise debt

### DIFF
--- a/lib/features/settlements/domain/models/transfer_breakdown.dart
+++ b/lib/features/settlements/domain/models/transfer_breakdown.dart
@@ -35,11 +35,11 @@ class ExpenseBreakdown {
   /// Description of how this expense affects the transfer
   String get explanation {
     if (netContribution > Decimal.zero) {
-      return 'Increases debt by ${netContribution.abs()}';
+      return 'Owes from this expense';
     } else if (netContribution < Decimal.zero) {
-      return 'Reduces debt by ${netContribution.abs()}';
+      return 'Is owed from this expense';
     } else {
-      return 'No net effect on debt';
+      return 'No direct debt from this expense';
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixed the transfer breakdown calculation to show direct pairwise debt instead of relative position changes, making it much clearer and more user-friendly.

## Problem

The previous formula was mathematically correct but conceptually confusing. For example, if Ethan paid ₫240,000 for a 3-way split where Izzy owes ₫80,000, it showed "Increases debt by ₫240,000" instead of the actual debt of ₫80,000.

## Solution

- Replaced relative position formula with direct pairwise debt calculation
- Updated wording to be clearer and more intuitive
- Numbers now match user expectations
- Sum of contributions equals the transfer amount
- Aligns with pairwise netting spec requirement (FR-011)

## Changes

1. `transfer_breakdown_calculator.dart`: New calculation logic
2. `transfer_breakdown.dart`: Improved explanation text

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)