### PR TITLE
fix: add back button to settlement page

### DIFF
--- a/lib/features/expenses/presentation/pages/expense_list_page.dart
+++ b/lib/features/expenses/presentation/pages/expense_list_page.dart
@@ -36,7 +36,7 @@ class ExpenseListPage extends StatelessWidget {
             icon: const Icon(Icons.account_balance_wallet),
             tooltip: 'View Settlement',
             onPressed: () {
-              context.go('/trips/$tripId/settlement');
+              context.push('/trips/$tripId/settlement');
             },
           ),
           IconButton(


### PR DESCRIPTION
Changed navigation method from `context.go()` to `context.push()` in expense_list_page.dart to preserve the navigation stack, enabling the automatic back button in the settlement page AppBar.

Fixes #10

Generated with [Claude Code](https://claude.ai/code)