### PR TITLE
Fix receipt split ignoring tax amount from receipt info step

### DIFF
--- a/lib/features/expenses/presentation/cubits/itemized_expense_cubit.dart
+++ b/lib/features/expenses/presentation/cubits/itemized_expense_cubit.dart
@@ -656,10 +656,24 @@ class ItemizedExpenseCubit extends Cubit<ItemizedExpenseState> {
     emit(ItemizedExpenseCalculating(validatedState));
 
     try {
+      // Build extras for calculation, including taxAmount from receipt info
+      // if not already set via extras.tax
+      Extras calculationExtras = validatedState.extras;
+      if (validatedState.taxAmount != null &&
+          validatedState.taxAmount! > Decimal.zero &&
+          validatedState.extras.tax == null) {
+        calculationExtras = validatedState.extras.copyWith(
+          tax: TaxExtra.amount(value: validatedState.taxAmount!),
+        );
+        debugPrint(
+          '🟡 [Cubit] Added taxAmount ${validatedState.taxAmount} to calculation extras',
+        );
+      }
+
       // Run calculation
       final participantBreakdown = _calculator.calculate(
         items: validatedState.items,
-        extras: validatedState.extras,
+        extras: calculationExtras,
         allocation: validatedState.allocation,
         currencyCode: validatedState.currencyCode,
       );


### PR DESCRIPTION
The taxAmount entered in Step 1 (Receipt Info) was being stored in state
but never converted to a TaxExtra and passed to the ItemizedCalculator.
This caused the tax to be completely ignored in per-person breakdowns.

The fix converts taxAmount to TaxExtra.amount() before calculation if:
- taxAmount is set and > 0
- extras.tax is not already set (allowing explicit tax config to override)